### PR TITLE
Allow base-4.17 and criterion-1.6, bump CI to 9.4.1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,18 +8,24 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.1
+# version: 0.15.20220808
 #
-# REGENDATA ("0.14.1",["github","xor.cabal"])
+# REGENDATA ("0.15.20220808",["github","xor.cabal"])
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+      - ci*
+  pull_request:
+    branches:
+      - master
+      - ci*
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -28,9 +34,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.1
+          - compiler: ghc-9.4.1
             compilerKind: ghc
-            compilerVersion: 9.2.1
+            compilerVersion: 9.4.1
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.4
+            compilerKind: ghc
+            compilerVersion: 9.2.4
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -96,18 +107,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -250,7 +261,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,1 +1,2 @@
+branches: master ci*
 installed: +all -binary -bytestring -directory -unix

--- a/xor.cabal
+++ b/xor.cabal
@@ -1,6 +1,7 @@
 cabal-version:       2.2
 name:                xor
 version:             0.0.1.1
+x-revision:          1
 
 category:            Data, Codec
 author:              Herbert Valerio Riedel
@@ -30,7 +31,8 @@ description:
   The performance is comparable to portable ISO C99 implementations but this library is implemented as pure Haskell and is thereby compatible with compile targets such as <https://github.com/ghcjs/ghcjs GHCJS>.
 
 tested-with:
-  GHC == 9.2.1
+  GHC == 9.4.1
+  GHC == 9.2.4
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4
@@ -58,7 +60,7 @@ common defaults
                        MagicHash
 
   build-depends:
-    , base            >= 4.5      && < 4.17
+    , base            >= 4.5      && < 4.18
     , bytestring      >= 0.10.4   && < 0.12
     , ghc-byteorder  ^>= 4.11.0.0
 
@@ -96,7 +98,7 @@ benchmark bench
   build-depends:
     , xor
       -- dependencies specific to this component
-    , criterion ^>= 1.5.6
+    , criterion ^>= 1.5.6 || ^>= 1.6.0.0
 
 test-suite test
   import: defaults


### PR DESCRIPTION
For GHC 9.4.1 and stackage:
-  https://github.com/commercialhaskell/stackage/issues/6677