### PR TITLE
v0.0.1.2: Address deprecation warning for memcpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+## 0.0.1.2
+
+_Andreas Abel, 2023-07-19_
+
+- Use `copyBytes` for deprecated `memcpy` as suggested by `bytestring-0.11.5`.
+- Tested with GHC 7.4 - 9.6.
+
 ## 0.0.1.1
 
 _Andreas Abel, 2022-02-16_

--- a/src-bench/Main.hs
+++ b/src-bench/Main.hs
@@ -25,6 +25,7 @@ import           Data.ByteString.Internal as BS
 import qualified Data.ByteString.Short    as SBS
 import           Data.Word                (Word32, Word8)
 import           Foreign.ForeignPtr
+import           Foreign.Marshal.Utils    (copyBytes)
 import           Foreign.Ptr
 import           Foreign.Storable
 import           GHC.ByteOrder            (ByteOrder (..), targetByteOrder)
@@ -106,7 +107,7 @@ xor32ByteString'v3 _ bs | BS.null bs = bs
 xor32ByteString'v3 msk0 (BS.PS x s l)
     = unsafeCreate l $ \p8 ->
         withForeignPtr x $ \f -> do
-          memcpy p8 (f `plusPtr` s) (fromIntegral l)
+          copyBytes p8 (f `plusPtr` s) (fromIntegral l)
           let p32 = castPtr p8 :: Ptr Word32
               l32 = l `quot` 4
               p32end = p32 `plusPtr` (l32*4)
@@ -122,7 +123,7 @@ xor32ByteString'v4  _ bs | BS.null bs = bs
 xor32ByteString'v4 msk0 (BS.PS x s l)
     = unsafeCreate l $ \p8 ->
         withForeignPtr x $ \f -> do
-          memcpy p8 (f `plusPtr` s) (fromIntegral l)
+          copyBytes p8 (f `plusPtr` s) (fromIntegral l)
           _ <- IUT.xor32CStringLen msk0 (castPtr p8,l)
           return ()
 
@@ -164,4 +165,3 @@ xor8Ptr1 msk ptr  = do { x <- peek ptr; poke ptr (xor msk x) }
 
 xor32Ptr1 :: Word32 -> Ptr Word32 -> IO ()
 xor32Ptr1 msk ptr = do { x <- peek ptr; poke ptr (xor msk x) }
-

--- a/src/Data/XOR.hs
+++ b/src/Data/XOR.hs
@@ -37,6 +37,7 @@ import           Endianness                     (ByteOrder (..), Word32, Word8, 
                                                  targetByteOrder)
 import           Foreign.C                      (CStringLen)
 import           Foreign.ForeignPtr             (withForeignPtr)
+import           Foreign.Marshal.Utils          (copyBytes)
 import           Foreign.Ptr                    (Ptr, alignPtr, castPtr, minusPtr, plusPtr)
 import           Foreign.Storable               (peek, poke)
 import           System.IO.Unsafe               (unsafeDupablePerformIO)
@@ -47,7 +48,7 @@ import qualified GHC.Word                       as X
 
 -- bytestring
 import qualified Data.ByteString                as BS
-import           Data.ByteString.Internal       (mallocByteString, memcpy)
+import           Data.ByteString.Internal       (mallocByteString)
 import qualified Data.ByteString.Internal       as BS (ByteString (..))
 import qualified Data.ByteString.Lazy.Internal  as BL (ByteString (..))
 import qualified Data.ByteString.Short          as SBS
@@ -136,7 +137,7 @@ xor32StrictByteString'' :: Word32 -> BS.ByteString -> (BS.ByteString,Word32)
 xor32StrictByteString'' msk0 (BS.PS x s l)
     = unsafeCreate' l $ \p8 ->
         withForeignPtr x $ \f -> do
-          memcpy p8 (f `plusPtr` s) (fromIntegral l)
+          copyBytes p8 (f `plusPtr` s) (fromIntegral l)
 
           case remPtr p8 4 of
             0 -> do

--- a/xor.cabal
+++ b/xor.cabal
@@ -1,11 +1,10 @@
 cabal-version:       2.2
 name:                xor
-version:             0.0.1.1
-x-revision:          3
+version:             0.0.1.2
 
 category:            Data, Codec
 author:              Herbert Valerio Riedel
-maintainer:          https://github.com/haskell-hvr/xor
+maintainer:          Andreas Abel
 bug-reports:         https://github.com/haskell-hvr/xor/issues
 
 copyright:           © 2020  Herbert Valerio Riedel
@@ -46,12 +45,12 @@ tested-with:
   GHC == 7.6.3
   GHC == 7.4.2
 
-extra-source-files:
+extra-doc-files:
   CHANGELOG.md
 
 source-repository head
   type:     git
-  location: https://github.com/hvr/xor.git
+  location: https://github.com/haskell-hvr/xor.git
 
 common defaults
   default-language:    Haskell2010


### PR DESCRIPTION
https://hackage.haskell.org/package/xor-0.0.1.2/candidate

Fixes #5