### PR TITLE
v0.0.1.4: drop obsolete dependency ghc-byteorder

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250506
+# version: 0.19.20251211
 #
-# REGENDATA ("0.19.20250506",["github","xor.cabal"])
+# REGENDATA ("0.19.20251211",["github","xor.cabal"])
 #
 name: Haskell-CI
 on:
@@ -18,6 +18,9 @@ on:
     branches:
       - master
   pull_request:
+    branches:
+      - master
+  merge_group:
     branches:
       - master
 jobs:
@@ -32,14 +35,19 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.0.20251128
+            compilerKind: ghc
+            compilerVersion: 9.14.0.20251128
+            setup-method: ghcup-prerelease
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.2
+          - compiler: ghc-9.10.3
             compilerKind: ghc
-            compilerVersion: 9.10.2
+            compilerVersion: 9.10.3
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.4
@@ -87,16 +95,6 @@ jobs:
             compilerVersion: 8.4.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.2.2
-            compilerKind: ghc
-            compilerVersion: 8.2.2
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-8.0.2
-            compilerKind: ghc
-            compilerVersion: 8.0.2
-            setup-method: ghcup
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt-get install
@@ -110,11 +108,26 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
           HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
@@ -136,7 +149,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -164,6 +177,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -187,7 +212,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -211,10 +236,17 @@ jobs:
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_xor}" >> cabal.project
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package xor" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          echo "package xor" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package xor" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package xor" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(xor)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 
+## 0.0.1.4
+
+_Andreas Abel, 2025-12-26_
+
+- Drop support for GHC 8.0 and 8.2.
+- Drop thus obsolete dependency `ghc-byteorder`.
+- Tested with GHC 8.4 - 9.14.
+
 ## 0.0.1.3
 
 _Andreas Abel, 2024-06-25_

--- a/src/Endianness.hs
+++ b/src/Endianness.hs
@@ -23,33 +23,10 @@ module Endianness
     ) where
 
 import           Data.Word        (Word16, Word32, Word64, Word8)
+import           Data.Word        (byteSwap16, byteSwap32, byteSwap64)
 import           Foreign.Ptr
 import           Foreign.Storable
 import           GHC.ByteOrder    (ByteOrder (..), targetByteOrder)
-
-#if MIN_VERSION_base(4,7,0)
-import           Data.Word        (byteSwap16, byteSwap32, byteSwap64)
-#else
-import           Data.Bits
-
--- supply missing byteSwap operations
-
-byteSwap16 :: Word16 -> Word16
-byteSwap16 = (`rotateL` 8)
-
-byteSwap32 :: Word32 -> Word32
-byteSwap32 x
-  = (x                  `shiftR` 24)  .|.
-    ((x .&. 0x00ff0000) `shiftR`  8)  .|.
-    ((x .&. 0x0000ff00) `shiftL`  8)  .|.
-    (x                  `shiftL` 24)
-
-byteSwap64 :: Word64 -> Word64
-byteSwap64 x = xh .|. (xl `shiftL` 32)
-  where
-    xl = fromIntegral (byteSwap32 (fromIntegral x))
-    xh = fromIntegral (byteSwap32 (fromIntegral (x `shiftR` 32)))
-#endif
 
 pokeWord16be :: Ptr Word16 -> Word16 -> IO ()
 pokeWord16be = case targetByteOrder of

--- a/xor.cabal
+++ b/xor.cabal
@@ -1,7 +1,6 @@
 cabal-version:       2.2
 name:                xor
-version:             0.0.1.3
-x-revision:          1
+version:             0.0.1.4
 
 category:            Data, Codec
 author:              Herbert Valerio Riedel
@@ -31,8 +30,9 @@ description:
   The performance is comparable to portable ISO C99 implementations but this library is implemented as pure Haskell and is thereby compatible with compile targets such as <https://github.com/ghcjs/ghcjs GHCJS>.
 
 tested-with:
+  GHC == 9.14.1
   GHC == 9.12.2
-  GHC == 9.10.2
+  GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8
@@ -42,8 +42,6 @@ tested-with:
   GHC == 8.8.4
   GHC == 8.6.5
   GHC == 8.4.4
-  GHC == 8.2.2
-  GHC == 8.0.2
 
 extra-doc-files:
   CHANGELOG.md
@@ -60,9 +58,10 @@ common defaults
                        MagicHash
 
   build-depends:
-    , base            >= 4.9      && < 5
-    , bytestring      >= 0.10.4   && < 0.13
-    , ghc-byteorder  ^>= 4.11.0.0
+    , base            >= 4.11      && < 5
+        -- GHC.ByteOrder ships with base-4.11 and up
+    , bytestring      >= 0.10.8.2  && < 0.13
+        -- bytestring-0.10.8.2 ships with GHC 8.4
 
   ghc-options:
     -Wall


### PR DESCRIPTION
Candidate: https://hackage.haskell.org/package/xor-0.0.1.4/candidate